### PR TITLE
serverのNODE_ENVをproductionに

### DIFF
--- a/udonite-server/Dockerfile
+++ b/udonite-server/Dockerfile
@@ -21,4 +21,5 @@ RUN npm install
 COPY --chown=${USERNAME}:${GROUPNAME} ./Udonite-Server .
 COPY --chown=${USERNAME}:${GROUPNAME} ./default.yaml ./config/
 
+STOPSIGNAL SIGINT
 CMD [ "./run.sh" ]

--- a/udonite-server/run.sh
+++ b/udonite-server/run.sh
@@ -2,4 +2,6 @@
 set -e
 
 sed -i -e "s/__HOST_NAME__/${NGINX_HOST}/g" ./config/default.yaml
+echo "# for node-config" > ./config/production.yaml
+export NODE_ENV=production
 exec npm start


### PR DESCRIPTION
https://expressjs.com/en/advanced/best-practice-performance.html#set-node_env-to-production

ここで書かれているとおりNODE_ENVをproductionにすることが推奨されているが、node-configとの兼ね合いで中身が空でない `production.yaml` が必要らしいのでそれを用意する